### PR TITLE
Allow specification of enum constants with additional attributes.

### DIFF
--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -81,7 +81,7 @@ module PersistentEnum
           current = values[name]
 
           if current.present?
-            current.assign_attributes(attrs)
+            current.assign_attributes(attrs, without_protection: true)
             current.save! if current.changed?
           else
             values[name] = model.create(name_attr => name, **attrs)

--- a/lib/persistent_enum/version.rb
+++ b/lib/persistent_enum/version.rb
@@ -1,3 +1,3 @@
 module PersistentEnum
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end


### PR DESCRIPTION
Add functionality to cache only existing table values.
Load existing values in a single query.
Add more tests.