### PR TITLE
Validate active enum members

### DIFF
--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -45,7 +45,11 @@ module PersistentEnum
         write_attribute(foreign_key, id)
       end
 
-      validates foreign_key, inclusion: { in: ->(r){ target_class.ordinals } }, allow_nil: true
+      # All enum members must be valid
+      validates foreign_key, inclusion: { in: ->(r){ target_class.all_ordinals } }, allow_nil: true
+
+      # New enum members must be currently active
+      validates foreign_key, inclusion: { in: ->(r){ target_class.ordinals } }, allow_nil: true, on: :create
     end
   end
 

--- a/lib/persistent_enum/acts_as_enum.rb
+++ b/lib/persistent_enum/acts_as_enum.rb
@@ -87,18 +87,26 @@ module PersistentEnum
 
       alias_method :with_name, :value_of
 
+      # Currently active ordinals
       def ordinals
         @acts_as_enum_state.required_by_ordinal.keys
       end
 
+      # Currently active enum members
       def values
         @acts_as_enum_state.required_by_ordinal.values
       end
 
+      def active?(member)
+        @acts_as_enum_state.required_by_ordinal.has_key?(member.ordinal)
+      end
+
+      # All ordinals, including of inactive enum members
       def all_ordinals
         @acts_as_enum_state.by_ordinal.keys
       end
 
+      # All enum members, including inactive
       def all_values
         @acts_as_enum_state.by_ordinal.values
       end
@@ -124,6 +132,11 @@ module PersistentEnum
 
     def ordinal
       read_attribute(:id)
+    end
+
+    # Is this enum member still present in the enum declaration?
+    def active?
+      self.class.active?(self)
     end
 
     class << self

--- a/lib/persistent_enum/version.rb
+++ b/lib/persistent_enum/version.rb
@@ -1,3 +1,3 @@
 module PersistentEnum
-  VERSION = "1.0.9"
+  VERSION = "1.0.11"
 end

--- a/test/unit/persistent_enum_test.rb
+++ b/test/unit/persistent_enum_test.rb
@@ -114,6 +114,8 @@ class PersistentEnumTest < ActiveSupport::TestCase
     assert_equal(existing_value, TestExisting[existing_value.ordinal])
     assert_equal(existing_value, TestExisting.value_of(existing_value.enum_constant))
 
+    assert(!existing_value.active?)
+
     destroy_test_model(:test_existing)
   end
 


### PR DESCRIPTION
Referring to an inactive enum member should be treated differently on create and save.