### PR TITLE
Allow acts_as_enum to be explicitly empty

### DIFF
--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -21,10 +21,10 @@ module PersistentEnum
           raise ArgumentError.new("Constants may not be provided both by argument and builder block")
         end
         required_constants = ConstantEvaluator.new.evaluate(&constant_init_block)
-      end
 
-      unless required_constants.present?
-        raise ArgumentError.new("No enum constants specified")
+        unless required_constants.present?
+          raise ArgumentError.new("No enum constants specified")
+        end
       end
 
       initialize_acts_as_enum(required_constants, name_attr, sql_enum_type)

--- a/lib/persistent_enum/acts_as_enum.rb
+++ b/lib/persistent_enum/acts_as_enum.rb
@@ -49,7 +49,7 @@ module PersistentEnum
         # Now we've ensured that our required constants are present, load the rest
         # of the enum from the database (if present)
         if table_exists?
-          values.concat(unscoped { where("id NOT IN (?)", values) })
+          values.concat(unscoped { where.not(id: values) })
         end
 
         values.each do |value|

--- a/spec/unit/persistent_enum_spec.rb
+++ b/spec/unit/persistent_enum_spec.rb
@@ -469,4 +469,25 @@ RSpec.describe PersistentEnum, :database do
       end
     }.to raise_error(RuntimeError, /unsafe class initialization during/)
   end
+
+  context "with an empty constants array" do
+    let(:initial_ordinal) { 9998 }
+    let(:initial_constant) { CONSTANTS.first }
+
+    let(:model) do
+      model = create_test_model(:with_empty_constants, ->(t) { t.string :name })
+      @prior_value = model.create!(id: initial_ordinal, name: initial_constant.to_s)
+      model.acts_as_enum([])
+      model
+    end
+
+    it "looks up the existing value" do
+      expect(model.value_of(initial_constant)).to eq(@prior_value)
+      expect(model[initial_ordinal]).to eq(@prior_value)
+    end
+
+    it "caches the existing value" do
+      expect(model.all_values).to eq([@prior_value])
+    end
+  end
 end


### PR DESCRIPTION
This covers the case where the enumeration is describing an existing
database that the application doesn't own. Allows `value_of`, `[]` and
`belongs_to_enum` to be used, but `all_values`/`all_ordinals` must
be used in place of `values`/`ordinals`.