### PR TITLE
Fix method_missing changing type of arguments

### DIFF
--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -305,17 +305,17 @@ module PersistentEnum
       alias_method :[], :read_attribute
 
       def method_missing(m, *args)
-        m = m.to_s
+        method_name = m.to_s
         case
-        when m == "id"
+        when method_name == "id"
           ordinal
-        when m == self.class.name_attr.to_s
+        when method_name == self.class.name_attr.to_s
           enum_constant
-        when @attributes.has_key?(m)
+        when @attributes.has_key?(method_name)
           if args.size > 0
             raise ArgumentError.new("wrong number of arguments (#{args.size} for 0)")
           end
-          @attributes[m]
+          @attributes[method_name]
         else
           super
         end


### PR DESCRIPTION
The call to `super` fails unless the argument type is a symbol, and
must not use the string version.