### PR TITLE
Index checks, upsert, refactor

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: trusty
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,20 @@ rvm:
 gemfile:
   - gemfiles/rails_5_0.gemfile
   - gemfiles/rails_5_1.gemfile
+env:
+  - TEST_DATABASE_ENVIRONMENT=postgresql
+  - TEST_DATABASE_ENVIRONMENT=mysql2
+  - TEST_DATABASE_ENVIRONMENT=sqlite3
 services:
   - postgresql
+  - mysql
 before_install:
   # Travis' Ruby 2.5.0 ships broken rubygems, won't run rake.
   # Workaround: update rubygems. See travis-ci issue 8978
   - gem update --system
 before_script:
   - psql -c 'CREATE DATABASE persistent_enum_test;' -U postgres
+  - mysql -e 'CREATE DATABASE persistent_enum_test;'
 addons:
   postgresql: "9.6"
 notifications:

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -121,6 +121,10 @@ module PersistentEnum
           required_attributes -= unknown_attributes
         end
 
+        unless model.connection.indexes(model.table_name).detect { |i| i.columns == [name_attr] && i.unique }
+          raise RuntimeError.new("PersistentEnum model #{model.name} detected missing unique index on '#{name_attr}': aborting.")
+        end
+
         if model.connection.open_transactions > 0
           raise RuntimeError.new("PersistentEnum model #{model.name} detected unsafe class initialization during a transaction: aborting.")
         end

--- a/persistent_enum.gemspec
+++ b/persistent_enum.gemspec
@@ -21,11 +21,15 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.0.0", "< 5.2"
   spec.add_dependency "activesupport", ">= 5.0.0", "< 5.2"
 
+  spec.add_dependency "activerecord-import"
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "mysql2"
+  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "pg", "~> 0.18" # As of 5.1.4, Rails runtime check excludes pg 1.x, see #31669
 
   spec.add_development_dependency "byebug"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,4 +99,8 @@ RSpec.configure do |config|
 =end
   require 'support/helpers/database_helper'
   config.include DatabaseHelper, :database
+
+  unless DatabaseHelper.db_env == 'postgresql'
+    config.filter_run_excluding :postgresql
+  end
 end

--- a/spec/support/config/database.yml
+++ b/spec/support/config/database.yml
@@ -1,4 +1,10 @@
 ---
-test:
+postgresql:
   adapter: postgresql
   database: persistent_enum_test
+mysql2:
+  adapter: mysql2
+  database: persistent_enum_test
+sqlite3:
+  adapter: sqlite3
+  database: ":memory:"

--- a/spec/support/helpers/database_helper.rb
+++ b/spec/support/helpers/database_helper.rb
@@ -2,18 +2,31 @@ require 'yaml'
 require 'active_record'
 
 module DatabaseHelper
-  def initialize_database
-    db_config_path = File.join(File.dirname(__FILE__), '../config/database.yml')
-    db_config = YAML.load(File.open(db_config_path))
-    raise "Test database configuration missing" unless db_config["test"]
-    ActiveRecord::Base.establish_connection(db_config["test"])
+  def self.db_env
+    ENV.fetch('TEST_DATABASE_ENVIROMENT', 'postgresql')
+  end
 
+  def self.initialize_database
+    db_config_path = File.join(File.dirname(__FILE__), '../config/database.yml')
+    db_config = YAML.safe_load(File.open(db_config_path))
+    raise "Test database configuration missing" unless db_config[db_env]
+    ActiveRecord::Base.establish_connection(db_config[db_env])
+
+    if ENV["DEBUG"]
+      ActiveRecord::Base.logger = Logger.new(STDERR)
+      ActiveRecord::Base.logger.level = Logger::DEBUG
+    end
+    db_env
+  end
+
+  def initialize_test_models
     @test_models = []
   end
 
   def create_test_model(name, columns, create_table: true, &block)
     if create_table
       table_name = name.to_s.pluralize
+      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{table_name}")
       ActiveRecord::Base.connection.create_table(table_name, &columns)
     end
 
@@ -28,7 +41,7 @@ module DatabaseHelper
   end
 
   def destroy_test_models
-    @test_models.each do |m|
+    @test_models.reverse_each do |m|
       destroy_test_model(m.name)
     end
     @test_models.clear
@@ -37,7 +50,7 @@ module DatabaseHelper
   def destroy_test_model(name)
     model_name = name.to_s.classify
     clazz = Object.const_get(model_name)
-    if !clazz.nil?
+    unless clazz.nil?
       table_name = clazz.table_name
       if clazz.table_exists?
         clazz.connection.drop_table(table_name, force: :cascade)

--- a/spec/support/helpers/database_helper.rb
+++ b/spec/support/helpers/database_helper.rb
@@ -53,7 +53,7 @@ module DatabaseHelper
     end
 
     table_name = clazz.table_name
-    if clazz.connection.table_exists?(table_name)
+    if clazz.connection.data_source_exists?(table_name)
       clazz.connection.drop_table(table_name, force: :cascade)
     end
 

--- a/spec/unit/persistent_enum_spec.rb
+++ b/spec/unit/persistent_enum_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe PersistentEnum, :database do
 
   context "with an enum model" do
     let(:model) do
-      create_test_model(:with_table, ->(t) { t.string :name }) do
+      create_test_model(:with_table, ->(t) { t.string :name; t.index [:name], unique: true }) do
         acts_as_enum(CONSTANTS)
       end
     end
@@ -180,7 +180,7 @@ RSpec.describe PersistentEnum, :database do
     let(:existing_constant) { :Hello }
 
     let!(:model) do
-      model = create_test_model(:with_existing, ->(t) { t.string :name })
+      model = create_test_model(:with_existing, ->(t) { t.string :name; t.index [:name], unique: true })
       @initial_value  = model.create(id: initial_ordinal, name: initial_constant.to_s)
       @existing_value = model.create(id: existing_ordinal, name: existing_constant.to_s)
       model.acts_as_enum(CONSTANTS)
@@ -238,7 +238,7 @@ RSpec.describe PersistentEnum, :database do
 
   context "with cached constants" do
     let(:model) do
-      create_test_model(:with_constants, ->(t) { t.string :name }) do
+      create_test_model(:with_constants, ->(t) { t.string :name; t.index [:name], unique: true }) do
         PersistentEnum.cache_constants(self, CONSTANTS)
       end
     end
@@ -267,7 +267,7 @@ RSpec.describe PersistentEnum, :database do
 
     let(:model) do
       test_constants = test_constants()
-      create_test_model(:with_complex_names, ->(t) { t.string :name }) do
+      create_test_model(:with_complex_names, ->(t) { t.string :name; t.index [:name], unique: true }) do
         PersistentEnum.cache_constants(self, test_constants.keys)
       end
     end
@@ -322,7 +322,7 @@ RSpec.describe PersistentEnum, :database do
     context "providing a hash" do
       let(:model) do
         members = members()
-        create_test_model(:with_extra_field, ->(t) { t.string :name; t.integer :count }) do
+        create_test_model(:with_extra_field, ->(t) { t.string :name; t.integer :count; t.index [:name], unique: true }) do
           # pre-existing matching, non-matching, and outdated data
           create(name: "One", count: 3)
           create(name: "Two", count: 2)
@@ -347,7 +347,7 @@ RSpec.describe PersistentEnum, :database do
 
     context "using builder interface" do
       let(:model) do
-        create_test_model(:with_extra_field_using_builder, ->(t) { t.string :name; t.integer :count }) do
+        create_test_model(:with_extra_field_using_builder, ->(t) { t.string :name; t.integer :count; t.index [:name], unique: true }) do
           acts_as_enum([]) do
             One(count: 1)
             Two(count: 2)
@@ -375,7 +375,7 @@ RSpec.describe PersistentEnum, :database do
 
     it "requires all required attributes to be provided" do
       expect {
-        create_test_model(:test_invalid_args_a, ->(t) { t.string :name; t.integer :count }) do
+        create_test_model(:test_invalid_args_a, ->(t) { t.string :name; t.integer :count; t.index [:name], unique: true }) do
           acts_as_enum([:Bad])
         end
       }.to raise_error(ArgumentError)
@@ -384,7 +384,7 @@ RSpec.describe PersistentEnum, :database do
 
     context "with attributes with defaults" do
       let(:model) do
-        create_test_model(:test_invalid_args_b, ->(t) { t.string :name; t.integer :count, default: 1 }) do
+        create_test_model(:test_invalid_args_b, ->(t) { t.string :name; t.integer :count, default: 1; t.index [:name], unique: true }) do
           acts_as_enum([]) do
             One()
             Two(count: 2)
@@ -404,7 +404,7 @@ RSpec.describe PersistentEnum, :database do
     end
 
     it "warns if nonexistent attributes are provided" do
-      create_test_model(:test_invalid_args_c, ->(t) { t.string :name }) do
+      create_test_model(:test_invalid_args_c, ->(t) { t.string :name; t.index [:name], unique: true }) do
         acts_as_enum({ :One => { incorrect: 1 } })
       end
 
@@ -422,6 +422,7 @@ RSpec.describe PersistentEnum, :database do
         ActiveRecord::Base.connection.create_table(name.pluralize, id: false) do |t|
           t.column :id, enum_type, primary_key: true, null: false
           t.string :name
+          t.index [:name], unique: true
         end
       end
 
@@ -453,7 +454,7 @@ RSpec.describe PersistentEnum, :database do
 
   context "with the name of the enum value column changed" do
     let(:model) do
-      create_test_model(:test_new_name, ->(t) { t.string :namey }) do
+      create_test_model(:test_new_name, ->(t) { t.string :namey; t.index [:namey], unique: true }) do
         acts_as_enum(CONSTANTS, name_attr: :namey)
       end
     end
@@ -463,11 +464,31 @@ RSpec.describe PersistentEnum, :database do
   it "refuses to create a table in a transaction" do
     expect {
       ActiveRecord::Base.transaction do
-        create_test_model(:test_create_in_transaction, ->(t) { t.string :name }) do
+        create_test_model(:test_create_in_transaction, ->(t) { t.string :name; t.index [:name], unique: true }) do
           acts_as_enum([:A, :B])
         end
       end
     }.to raise_error(RuntimeError, /unsafe class initialization during/)
+  end
+
+  it "refuses to create an enum without an index on the enum constant" do
+    expect {
+      ActiveRecord::Base.transaction do
+        create_test_model(:test_create_without_index, ->(t) { t.string :name }) do
+          acts_as_enum([:A, :B])
+        end
+      end
+    }.to raise_error(RuntimeError, /missing unique index/)
+  end
+
+  it "refuses to create an enum without a unique index on the enum constant" do
+    expect {
+      ActiveRecord::Base.transaction do
+        create_test_model(:test_create_without_index, ->(t) { t.string :name; t.index [:name] }) do
+          acts_as_enum([:A, :B])
+        end
+      end
+    }.to raise_error(RuntimeError, /missing unique index/)
   end
 
   context "with an empty constants array" do
@@ -475,7 +496,7 @@ RSpec.describe PersistentEnum, :database do
     let(:initial_constant) { CONSTANTS.first }
 
     let(:model) do
-      model = create_test_model(:with_empty_constants, ->(t) { t.string :name })
+      model = create_test_model(:with_empty_constants, ->(t) { t.string :name; t.index [:name], unique: true })
       @prior_value = model.create!(id: initial_ordinal, name: initial_constant.to_s)
       model.acts_as_enum([])
       model

--- a/spec/unit/persistent_enum_spec.rb
+++ b/spec/unit/persistent_enum_spec.rb
@@ -386,7 +386,6 @@ RSpec.describe PersistentEnum, :database do
           acts_as_enum([:Bad])
         end
       }.to raise_error(ArgumentError)
-      destroy_test_model(:test_invalid_args_a)
     end
 
     context "with attributes with defaults" do


### PR DESCRIPTION
Fixes race condition during load in the case of missing index on the enum constant.
Inserts records with upsert when using supported database.
Adds support for case-insensitive constant lookup.
Cleans up state initialization.