### PR TITLE
Try much harder to allow successful Rails startup

### DIFF
--- a/lib/persistent_enum/version.rb
+++ b/lib/persistent_enum/version.rb
@@ -1,3 +1,3 @@
 module PersistentEnum
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Even when table initialization fails. We now fall back to using dummy model in
all cases except initialization in a transaction. The latter is omitted as it's
likely to be a sign that the models weren't initialized at startup, so falling
back to a dummy model could go ignored.