### PR TITLE
reuse cached values when reinitializing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ services:
 before_install:
   # Travis' Ruby 2.5.0 ships broken rubygems, won't run rake.
   # Workaround: update rubygems. See travis-ci issue 8978
-  - gem update --system
+  - gem install bundler
 before_script:
   - psql -c 'CREATE DATABASE persistent_enum_test;' -U postgres
   - mysql -e 'CREATE DATABASE persistent_enum_test;'

--- a/lib/persistent_enum/version.rb
+++ b/lib/persistent_enum/version.rb
@@ -1,3 +1,3 @@
 module PersistentEnum
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
When reinitializing, reuse existing constant cached models if they refer to
the same enum constant.