### PR TITLE
Use `reload` to sync changed attributes

### DIFF
--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -293,14 +293,14 @@ module PersistentEnum
 
         if model.const_defined?(constant_name, false)
           existing_value = model.const_get(constant_name, false)
-          if existing_value.read_attribute(name_attr) != value.read_attribute(name_attr)
+          if existing_value.is_a?(AbstractDummyModel) ||
+             existing_value.read_attribute(name_attr) != value.read_attribute(name_attr)
+          then
             # Replace with new value
             model.send(:remove_const, constant_name)
             model.const_set(constant_name, value)
           elsif existing_value.attributes != value.attributes
-            existing_value.attributes = value.attributes
-            existing_value.clear_changes_information
-            existing_value
+            existing_value.reload.freeze
           else
             existing_value
           end

--- a/lib/persistent_enum/version.rb
+++ b/lib/persistent_enum/version.rb
@@ -1,3 +1,3 @@
 module PersistentEnum
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/spec/unit/persistent_enum_spec.rb
+++ b/spec/unit/persistent_enum_spec.rb
@@ -397,13 +397,16 @@ RSpec.describe PersistentEnum, :database do
         end
 
         it "handles a change in an attribute" do
-          model.where(name: "One").update_all(count: 10)
-          old_constant = model.const_get(:ONE).reload
-          expect(old_constant.count).to eq(10)
+          old_constant = model.const_get(:ONE)
 
-          model.reinitialize_acts_as_enum
+          state = model._acts_as_enum_state
+          model.initialize_acts_as_enum(
+            state.required_members.merge({ "One" => { count: 1111 } }),
+            state.name_attr,
+            state.sql_enum_type)
+
           new_constant = model.const_get(:ONE)
-          expect(new_constant.count).to eq(1)
+          expect(new_constant.count).to eq(1111)
           expect(new_constant).to equal(old_constant)
           expect(new_constant).to equal(model.value_of("One"))
         end


### PR DESCRIPTION
Prevents attempts to assign to frozen models, which were accidentally
unfrozen in tests by calling `reload`.