### PR TITLE
Assert default values when omitted from acts_as_enum

### DIFF
--- a/spec/unit/persistent_enum_spec.rb
+++ b/spec/unit/persistent_enum_spec.rb
@@ -525,13 +525,16 @@ RSpec.describe PersistentEnum, :database do
     end
 
     context "with attributes with defaults" do
+      let(:prepopulate) { nil }
       let(:model) do
+        pp = prepopulate
         create_test_model(:test_invalid_args_b, ->(t) {
                             t.string :name
                             t.integer :count, default: 1, null: false
                             t.integer :maybe
                             t.index [:name], unique: true
                           }) do
+          pp&.call(self)
           acts_as_enum(nil) do
             One()
             Two(count: 2)
@@ -555,6 +558,21 @@ RSpec.describe PersistentEnum, :database do
         expect(r).to be_present
         expect(r.count).to eq(1)
         expect(r.maybe).to eq(1)
+      end
+
+      context "with non-default existing values" do
+        let(:prepopulate) do
+          ->(table) do
+            table.create!(name: "One", count: 10, maybe: 10)
+          end
+        end
+
+        it "asserts the defaults when omitted" do
+          o = model.value_of("One")
+          expect(o).to be_present
+          expect(o.count).to eq(1)
+          expect(o.maybe).to eq(nil)
+        end
       end
     end
 

--- a/spec/unit/persistent_enum_spec.rb
+++ b/spec/unit/persistent_enum_spec.rb
@@ -525,16 +525,17 @@ RSpec.describe PersistentEnum, :database do
     end
 
     context "with attributes with defaults" do
-      let(:prepopulate) { nil }
+      def prepopulate(table); end
+
       let(:model) do
-        pp = prepopulate
+        pp_handle = method(:prepopulate)
         create_test_model(:test_invalid_args_b, ->(t) {
                             t.string :name
                             t.integer :count, default: 1, null: false
                             t.integer :maybe
                             t.index [:name], unique: true
                           }) do
-          pp&.call(self)
+          pp_handle.call(self)
           acts_as_enum(nil) do
             One()
             Two(count: 2)
@@ -561,10 +562,8 @@ RSpec.describe PersistentEnum, :database do
       end
 
       context "with non-default existing values" do
-        let(:prepopulate) do
-          ->(table) do
-            table.create!(name: "One", count: 10, maybe: 10)
-          end
+        def prepopulate(table)
+          table.create!(name: "One", count: 10, maybe: 10)
         end
 
         it "asserts the defaults when omitted" do


### PR DESCRIPTION
Columns with default values are allowed to be omitted from an acts_as_enum
specification. These were left up to the database to initialize when
upserting the rows. This meant that if a enum member was changed from a
non-default value to default by removing the attribute declaration then
the table contents would not be updated to the new default value.