### PR TITLE
Use `column_names` rather than `attribute_names` to enumerate table

### DIFF
--- a/lib/persistent_enum.rb
+++ b/lib/persistent_enum.rb
@@ -184,7 +184,7 @@ module PersistentEnum
       end
 
       internal_attributes = ["id", name_attr]
-      table_attributes = (model.attribute_names - internal_attributes)
+      table_attributes = (model.column_names - internal_attributes)
 
       # If not otherwise specified, non-null attributes without defaults are required
       optional_attributes = model.columns.select { |col| col.null || !col.default.nil? }.map(&:name) - internal_attributes

--- a/lib/persistent_enum/version.rb
+++ b/lib/persistent_enum/version.rb
@@ -1,3 +1,3 @@
 module PersistentEnum
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
Attribute names also include attributes that have custom serializers defined but may not yet exist in the database.